### PR TITLE
Add ground truths only data loader

### DIFF
--- a/LION/data_loaders/deteCT.py
+++ b/LION/data_loaders/deteCT.py
@@ -387,7 +387,7 @@ class deteCT(Dataset):
         if self.task in ["sino2sino", "sino2recon", "sino2seg", "joint"]:
             input = self.__load_and_preprocess_sinogram__(index, self.input_mode)
         # if input is reconstruction, we need to load the reconstruction
-        elif self.task != "groundtruth":
+        else:
             # Even if input is recon, we may want to actually do it ourselves.
             if self.do_recon:
                 sinogram = self.__load_and_preprocess_sinogram__(index, self.input_mode)

--- a/LION/data_loaders/deteCT.py
+++ b/LION/data_loaders/deteCT.py
@@ -416,9 +416,10 @@ class deteCT(Dataset):
                     target = nag_ls(op, sinogram, 100, min_constraint=0)
                 elif self.recon_algo == "fdk":
                     target = fdk(op, sinogram)
-            target = self.__load_and_preprocess_reconstruction__(
-                index, self.target_mode
-            )
+            else:
+                target = self.__load_and_preprocess_reconstruction__(
+                    index, self.target_mode
+                )
         elif self.task in ["recon2seg", "sino2seg"]:
             # Get paths to the dataset
             target = self.__load_and_preprocess_segmentation__(index)

--- a/LION/experiments/ct_benchmarking_experiments.py
+++ b/LION/experiments/ct_benchmarking_experiments.py
@@ -30,6 +30,30 @@ class CTBenchmarkingExperiment(Experiment):
         super().__init__(experiment_params, dataset, datafolder)
 
 
+class GroundTruthCT(CTBenchmarkingExperiment):
+    def __init__(self, datafolder=None):
+        super().__init__(experiment_params=None, datafolder=datafolder)
+
+    @staticmethod
+    def default_parameters(dataset="2DeteCT"):
+        param = LIONParameter()
+
+        param.name = "Ground truths only, from Full Data CT reconstruction using the full angular sampling experiment from mode 2"
+
+        # Parameters for the geometry
+        param.geo = deteCT.get_default_geometry()
+
+        param.data_loader_params = Experiment.get_dataset_parameters("2DeteCT")
+
+        # Change the data loader to be groundtruth
+        param.data_loader_params.task = "groundtruth"
+        param.data_loader_params.input_mode = "mode2"
+        param.data_loader_params.target_mode = "mode2"
+        param.do_recon = False
+
+        return param
+
+
 class FullDataCTRecon(CTBenchmarkingExperiment):
     def __init__(self, datafolder=None):
         super().__init__(experiment_params=None, datafolder=datafolder)


### PR DESCRIPTION
This adds a `CTBenchmarkingExperiment`, called `GroundTruthCT`, and a corresponding task `'groundtruth'`, which only loads the ground truth reconstructions, for example for use in training a denoiser. The time saved processing the sinograms (which happens on CPU) allows for higher GPU utilisation.

The issue of time wasted on preprocessing sinograms when only training denoisers was mentioned in #92.