### PR TITLE
Fixing validation routine for supervised learning

### DIFF
--- a/LION/optimizers/supervised_learning.py
+++ b/LION/optimizers/supervised_learning.py
@@ -81,7 +81,7 @@ class supervisedSolver(LIONsolver):
         ):
             with torch.no_grad():
                 output = self.model(data.to(self.device))
-                validation_loss = self.validation_fn(output, target.to(self.device))
+                validation_loss += self.validation_fn(output, target.to(self.device))
 
         # return to train if it was in train
         if status:


### PR DESCRIPTION
Validation routine for supervised learning previously evaluated validation loss only on the last element instead of the whole data_loader. Fixed now.