### PR TITLE
Add FBPConvNet test demo script. Fix typos. Fix FBPConvNet_train.py.

### DIFF
--- a/LION/models/README.md
+++ b/LION/models/README.md
@@ -6,9 +6,9 @@ There are 5 existing ways of doing CT reconstruction using data-driven methods:
 - Post-Processing methods: a "denoising" network. Takes a noisy recon and cleans it.
 - Iterative Unrolled methods: Uses the operator to imitate iterative recon algorithms, but has learned parts.
 - Learned regularizer: Explicitly learned regularization functions.
-- Plung and Play (PnP): Implicit learned regularization, a regularization optimization step is learned, rather than an explicit one. 
+- Plug and Play (PnP): Implicit learned regularization, a regularization optimization step is learned, rather than an explicit one. 
 
-On top of these, there are some techniques that don't fit this classification, particularly because they reffer to _modes of training_ rather than methodology. For these, often the model is not the important part, but the way of training. We will mention them here anyway, to avoid information fragmentation. 
+On top of these, there are some techniques that don't fit this classification, particularly because they refer to _modes of training_ rather than methodology. For these, often the model is not the important part, but the way of training. We will mention them here anyway, to avoid information fragmentation. 
 They tend to be either
 
 - Self-supervised networks: Uses noisy data to self train and obtain noisseless recosntruction.
@@ -35,7 +35,7 @@ LION supports the following models for each category
 
 WIP
 
-## Plung and Play
+## Plug and Play
 
 WIP
 

--- a/LION/models/post_processing/FBPConvNet.py
+++ b/LION/models/post_processing/FBPConvNet.py
@@ -63,7 +63,7 @@ class Down(nn.Module):
 
 
 class Up(nn.Module):
-    """Downscaling with transpose conv"""
+    """Upscaling with transpose conv"""
 
     def __init__(self, channels, stride=2, relu_type="ReLU"):
         super().__init__()
@@ -254,4 +254,5 @@ class FBPConvNet(LIONmodel.LIONmodel):
         res = self.block_3_up(torch.cat((block_2_res, self.up_3(res)), dim=1))
         res = self.block_4_up(torch.cat((block_1_res, self.up_4(res)), dim=1))
         res = self.block_last(res)
+        
         return image + res

--- a/scripts/example_scripts/FBPConvNet_test.py
+++ b/scripts/example_scripts/FBPConvNet_test.py
@@ -1,0 +1,42 @@
+import torch
+from torch.utils.data import DataLoader
+import pathlib
+from LION.models.post_processing.FBPConvNet import FBPConvNet
+import matplotlib.pyplot as plt
+import LION.experiments.ct_experiments as ct_experiments
+
+
+#%% First run FBPConvNet_train.py to train and save model, then run this.
+# % Set device:
+device = torch.device("cuda:0")
+torch.cuda.set_device(device)
+# Give paths to trained models
+savefolder = pathlib.Path("/store/DAMTP/cs2186/trained_models/clinical_dose/")
+final_result_fname = savefolder.joinpath("FBPConvNet_final_iter.pt")
+
+# set up experiment model was trained on
+# the same experiment should be used, results cannot be guaranteed otherwise
+experiment = ct_experiments.clinicalCTRecon()
+test_data = experiment.get_testing_dataset()
+test_dataloader = DataLoader(test_data, 1, shuffle=True)
+
+# load trained model
+model, _, _ = FBPConvNet.load(final_result_fname)
+model.to(device)
+
+# sample a random batch (size 1, so really just one image, truth pair)
+data, gt = next(iter(test_dataloader))
+x = model(data)
+
+# put stuff back on the cpu, otherwise matplotlib throws an error
+x = x.detach().cpu().numpy()
+gt = gt.detach().cpu().numpy()
+
+plt.figure()
+plt.subplot(121)
+plt.imshow(x[0].T)
+plt.colorbar()
+plt.subplot(122)
+plt.imshow(gt[0].T)
+plt.colorbar()
+plt.savefig("img.png")


### PR DESCRIPTION
FBPConvNet_test.py - small test script to show trained models performance on unseen data. Largely for visual purposes. In future may create a more generic tool for this.

FBPConvNet_train.py - removed redundant imports and fixed outdated imports - Parameter in place of LIONParameter seems to appear a lot throughout the repo. Fixed test logic, fdk was applied to data before feeding it into FBPConvNet, which already applied fdk internally; FBPConvNet expects a sinogram.