### PR TITLE
add normalization to LionSolver

### DIFF
--- a/LION/optimizers/LIONsolver.py
+++ b/LION/optimizers/LIONsolver.py
@@ -49,7 +49,6 @@ class SolverParams(LIONParameter):
 def normalize_input(func):
     def wrapper(self, *inputs):
         if self.do_normalize:
-            print(inputs)
             normalized_inputs = []
             for x in inputs:
                 normalized_x = (x - self.xmin) / (self.xmax - self.xmin)

--- a/LION/optimizers/LIONsolver.py
+++ b/LION/optimizers/LIONsolver.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Callable, Optional
 from LION.CTtools.ct_geometry import Geometry
 from LION.CTtools.ct_utils import make_operator
+from LION.exceptions.exceptions import NoDataException
 from LION.utils.parameter import LIONParameter
 
 # Lionmodels
@@ -45,6 +46,19 @@ class SolverParams(LIONParameter):
     def __init__(self):
         super().__init__()
 
+def normalize_input(func):
+    def wrapper(self, *inputs):
+        if self.do_normalize:
+            print(inputs)
+            normalized_inputs = []
+            for x in inputs:
+                normalized_x = (x - self.xmin) / (self.xmax - self.xmin)
+                normalized_inputs.append(normalized_x)
+            return func(self, *normalized_x)
+        else:
+            return func(self, *inputs)
+    return wrapper
+
 
 class LIONsolver(ABC, metaclass=ABCMeta):
     def __init__(
@@ -58,9 +72,11 @@ class LIONsolver(ABC, metaclass=ABCMeta):
         verbose: bool=True,
         device: torch.device = torch.device(f"cuda:{torch.cuda.current_device()}"),
         model_regularization=None,
-        solver_params: SolverParams=SolverParams()
+        solver_params: Optional[SolverParams]=None
     ) -> None:
         super().__init__()
+        if solver_params is None:
+            self.solver_params = self.default_parameters()
 
         assert isinstance(model, LIONmodel), "model must be a LIONmodel"
         assert isinstance(
@@ -73,9 +89,10 @@ class LIONsolver(ABC, metaclass=ABCMeta):
         self.model = model
         self.optimizer = optimizer
         self.geo = geometry
+        self.train_loader: Optional[DataLoader] = None
+        self.train_loss: np.ndarray = np.zeros(0)
         self.loss_fn = loss_fn
         self.device = device
-        self.train_loss: np.ndarray = np.zeros(0)
         self.validation_loader: Optional[DataLoader] = None
         self.validation_fn: Optional[Callable] = None
         self.validation_freq: Optional[int] = None
@@ -95,6 +112,11 @@ class LIONsolver(ABC, metaclass=ABCMeta):
         self.model_regularization = model_regularization
         self.metadata = LIONParameter()
         self.dataset_param = LIONParameter()
+
+        # normalization stuff
+        self.do_normalize: bool = False
+        self.xmin: Optional[float] = None
+        self.xmax: Optional[float] = None
 
     # This should return the default parameters of the solver
     @staticmethod
@@ -145,6 +167,20 @@ class LIONsolver(ABC, metaclass=ABCMeta):
         self.checkpoint_freq = checkpoint_freq
         self.checkpoint_fname = checkpoint_fname
         self.do_load_checkpoint = load_checkpoint
+
+    def set_normalization(self, do_normalize: bool):
+        if self.train_loader is None:
+            raise NoDataException("Training dataloader not set: Please call set_training")
+        self.do_normalize = do_normalize
+        if self.do_normalize:
+            xmax = -np.inf
+            xmin = np.inf
+            for x in self.train_loader:
+                xmax = max(x[1].max(), xmax)
+                xmin = min(x[1].min(), xmin)
+            self.xmin = xmin
+            self.xmax = xmax
+
 
     def check_training_ready(self, error=True, autofill=True, verbose=True):
         """This should always pass, all of these things are required to initialize a LIONsolver object
@@ -487,7 +523,16 @@ class LIONsolver(ABC, metaclass=ABCMeta):
         # TODO: This doesn't delete the .jsons only the .pt, is this intentional behaviour?
         for f in self.save_folder.glob(str(self.checkpoint_fname).replace("*", "*")):
             f.unlink()
-        
+    
+    def normalize(self, x):
+        """Normalizes input data
+        returns: Normalized input data
+        """
+        if self.do_normalize:
+            assert self.xmax is not None and self.xmin is not None
+            normalized_x = (x - self.xmin) / (self.xmax - self.xmin)
+        return normalized_x
+
     @abstractmethod
     def test(self):
         """

--- a/LION/optimizers/supervised_learning.py
+++ b/LION/optimizers/supervised_learning.py
@@ -1,5 +1,6 @@
 # numerical imports
 import pathlib
+from typing import Optional
 import torch
 import torch.nn as nn
 import numpy as np
@@ -7,7 +8,7 @@ import numpy as np
 # Import base class
 from LION.CTtools.ct_geometry import Geometry
 from LION.CTtools.ct_utils import make_operator
-from LION.exceptions.exceptions import LIONSolverException
+from LION.exceptions.exceptions import LIONSolverException, NoDataException
 from LION.models.LIONmodel import LIONmodel, ModelInputType
 from LION.optimizers.LIONsolver import LIONsolver, SolverParams
 from LION.classical_algorithms.fdk import fdk
@@ -15,20 +16,21 @@ from LION.classical_algorithms.fdk import fdk
 # standard imports
 from tqdm import tqdm
 
+from LION.utils.parameter import LIONParameter
+
 
 class SupervisedSolver(LIONsolver):
     def __init__(
         self,
         model: LIONmodel,
         optimizer: torch.optim.Optimizer,
-        loss_fn: nn.Module,
-        save_folder: pathlib.Path,
-        final_result_fname: str,
+        loss_fn: torch.nn.Module,
+        verbose: bool,
         geo: Geometry,
-        verbose=False,
-        device=torch.device(f"cuda:{torch.cuda.current_device()}"),
+        save_folder: str | pathlib.Path,
+        final_result_fname: str,
         model_regularization=None,
-        solver_params: SolverParams=SolverParams(),
+        device: torch.device = torch.device(f"cuda:{torch.cuda.current_device()}")
     ):
         super().__init__(
             model,
@@ -40,7 +42,7 @@ class SupervisedSolver(LIONsolver):
             verbose=verbose,
             device=device,
             model_regularization=model_regularization,
-            solver_params=solver_params
+            solver_params=SolverParams()
         )
         self.op = make_operator(self.geo)
 
@@ -52,6 +54,10 @@ class SupervisedSolver(LIONsolver):
         if self.model.model_parameters.model_input_type == ModelInputType.NOISY_RECON:
             # reconstruct sino using fdk
             data = fdk(data, self.op)
+
+        if self.do_normalize:
+            data = self.normalize(data)
+
         # Zero gradients
         self.optimizer.zero_grad()
         # Forward pass
@@ -73,6 +79,8 @@ class SupervisedSolver(LIONsolver):
         This function is responsible for performing a single tranining set epoch of the optimization.
         returns the average loss of the epoch
         """
+        if self.train_loader is None:
+            raise NoDataException("Training dataloader not set: Please call set_training")
         self.model.train()
         epoch_loss = 0.0
         for _, (data, target) in enumerate(tqdm(self.train_loader)):

--- a/scripts/example_scripts/noise2inverse2.py
+++ b/scripts/example_scripts/noise2inverse2.py
@@ -77,6 +77,7 @@ solver = Noise2InverseSolver(
 
 # set data
 solver.set_training(lidc_dataloader)
+solver.set_normalization(True)
 solver.set_testing(lidc_test, my_ssim)
 
 # set checkpointing procedure


### PR DESCRIPTION
Zak mentioned that it is often beneficial to normalize inputs.
This is done using global dataset statistics, so shouldn't be the job of a LIONModel, who has no knowledge of the dataset, rather the job of the LIONSolver who does.

Added functions to optionally enable normalization and logic in existing solvers to leverage this.