### PR TITLE
Remove confusing `fan` suffix from `forward_projection` function

### DIFF
--- a/LION/CTtools/ct_utils.py
+++ b/LION/CTtools/ct_utils.py
@@ -157,7 +157,7 @@ def make_operator(geo: Geometry):
     return A
 
 
-def forward_projection_fan(image, geo, backend="tomosipo"):
+def forward_projection(image, geo, backend="tomosipo"):
     """
     Produces a noise free forward projection, given np.array image, a size (in real world units), a sinogram shape and size,
     distances from source to detector DSD and distance from source to object DSO.

--- a/demos/d01_ct_simulation.py
+++ b/demos/d01_ct_simulation.py
@@ -137,7 +137,7 @@ phantom = torch.from_numpy(phantom).to(dev)
 # In essence, this is the same as using the operator we defined above.
 
 # We can use the following function
-sino = ct.forward_projection_fan(phantom, geo)
+sino = ct.forward_projection(phantom, geo)
 # If you defined the operator as in step 3 or 4, you can also do (its the same):
 sino = A(phantom)
 # For noise simulation, a good approximation of CT noise is to add Poisson noise to the non-log transformed sinograms,


### PR DESCRIPTION
The function `forward_projection_fan` is not specific to fan-beam geometries (for example, in d01_ct_simulation.py, it is applied to a parallel-beam geometry), so the suffix `_fan` can be dropped to avoid confusion.