### PR TITLE
Match DnCNN default hyperparameters to benchmark settings

### DIFF
--- a/LION/models/PnP/dncnn.py
+++ b/LION/models/PnP/dncnn.py
@@ -69,7 +69,7 @@ class DnCNN(LIONmodel):
             kernel_size=(3, 3),
             blocks=20,
             residual=True,
-            bias_free=False,
+            bias_free=True,
             act="leaky_relu",
             enforce_positivity=False,
             batch_normalisation=True,


### PR DESCRIPTION
Update the default DnCNN to be bias-free, as it was in the benchmarking project. This way, the hyperparameters do not need to be changed to load the saved weights from that project.