### PR TITLE
Fix FBPConvNet imports and add parallel-beam variant

### DIFF
--- a/LION/models/post_processing/FBPConvNet.py
+++ b/LION/models/post_processing/FBPConvNet.py
@@ -2,14 +2,14 @@
 # License : BSD-3
 #
 # Author  : Ander Biguri
-# Modifications: -
+# Modifications: Emilia Zabrzanska (2026): fix LIONmodel namespace references
 # =============================================================================
 
 
 from typing import Optional
 import torch
 import torch.nn as nn
-from LION.models.LIONmodel import LIONModelParameter, LIONmodel
+from LION.models.LIONmodel import LIONModelParameter, LIONmodel, ModelInputType
 import LION.CTtools.ct_geometry as ct
 from LION.classical_algorithms.fdk import fdk
 
@@ -91,11 +91,11 @@ class Up(nn.Module):
         return self.block(x)
 
 
-class FBPConvNet(LIONmodel.LIONmodel):
+class FBPConvNet(LIONmodel):
     def __init__(
         self,
         geometry_parameters: ct.Geometry,
-        model_parameters: Optional[LIONmodel.LIONModelParameter] = None,
+        model_parameters: Optional[LIONModelParameter] = None,
     ):
 
         assert (
@@ -203,7 +203,7 @@ class FBPConvNet(LIONmodel.LIONmodel):
         params.up_4_channels = [128, 64, 64]
         params.last_block = [64, 1, 1]
         params.activation = "ReLU"
-        params.model_input_type = LIONmodel.ModelInputType.SINOGRAM
+        params.model_input_type = ModelInputType.SINOGRAM
         return params
 
     @staticmethod
@@ -213,7 +213,7 @@ class FBPConvNet(LIONmodel.LIONmodel):
             print(
                 '"Deep convolutional neural network for inverse problems in imaging."'
             )
-            print("\x1B[3mIEEE Transactions on Image Processing \x1B[0m")
+            print("\x1b[3mIEEE Transactions on Image Processing \x1b[0m")
             print(" 26.9 (2017): 4509-4522.")
         elif cite_format == "bib":
             string = """

--- a/LION/models/post_processing/FBPConvNetImage.py
+++ b/LION/models/post_processing/FBPConvNetImage.py
@@ -1,0 +1,31 @@
+# This file is part of LION library
+# License : BSD-3
+#
+# Author  : Emilia Zabrzanska
+# Modifications: -
+# =============================================================================
+
+import torch
+from LION.models.post_processing.FBPConvNet import FBPConvNet
+
+
+class FBPConvNetImage(FBPConvNet):
+    """
+    FBPConvNet that takes a pre-computed FBP image as input instead of calling FDK inside the forward pass.
+    """
+
+    def forward(self, image):
+
+        block_1_res = self.block_1_down(image)
+        block_2_res = self.block_2_down(self.down_1(block_1_res))
+        block_3_res = self.block_3_down(self.down_2(block_2_res))
+        block_4_res = self.block_4_down(self.down_3(block_3_res))
+
+        res = self.block_bottom(self.down_4(block_4_res))
+        res = self.block_1_up(torch.cat((block_4_res, self.up_1(res)), dim=1))
+        res = self.block_2_up(torch.cat((block_3_res, self.up_2(res)), dim=1))
+        res = self.block_3_up(torch.cat((block_2_res, self.up_3(res)), dim=1))
+        res = self.block_4_up(torch.cat((block_1_res, self.up_4(res)), dim=1))
+        res = self.block_last(res)
+
+        return image + res


### PR DESCRIPTION
## Summary

Fixes two issues with `LION/models/post_processing/FBPConvNet.py` that prevented its use as a baseline for sparse-view CT reconstruction with parallel-beam geometry.

## Changes

### 1. Import inconsistencies in `FBPConvNet.py` (commit 1)

The from-import imports `LIONmodel` as a class, but three references on lines 94, 98 and 206 (`LIONmodel.LIONmodel`, `LIONmodel.LIONModelParameter`, `LIONmodel.ModelInputType`) treat it as a module, causing an `AttributeError` at class definition time.

Patched by dropping the module-prefix and adding `ModelInputType` to the from-import.

### 2. Parallel-beam support through a new `FBPConvNetImage` class (commit 2)

The existing `FBPConvNet` calls `fdk(x, self.op)` unconditionally in the forward pass. LION's `fdk` only supports cone-beam geometries, raising a `TypeError` for all other cases. 

The new `FBPConvNetImage` class takes a pre-computed FBP image directly, skipping the internal reconstruction step. 

The architecture, residual connection, parameters, and `default_parameters()` are inherited without changes from `FBPConvNet`.

This change is non-breaking, with existing `FBPConvNet` users seeing no change.

## Testing

Both fixes were verified locally on parallel-beam LIDC-IDRI sparse-view CT (30 angles, 512×512 images, 5% Gaussian noise). 

`FBPConvNetImage` trained on 250 images for 80 epochs and reached 29.1 dB validation PSNR.

## Future work (not in this PR)

Long term, the cleanest fix for Issue 2 would be making `FBPConvNet.forward()` dispatch to the appropriate reconstructor by geometry type,  requiring LION to expose a parallel-beam FBP function at the same level as `fdk`.