### PR TITLE
Fix #146: Allow alternative solvers for IMAGE input data

### DIFF
--- a/LION/optimizers/SupervisedSolver.py
+++ b/LION/optimizers/SupervisedSolver.py
@@ -27,6 +27,7 @@ class SupervisedSolver(LIONsolver):
         model_regularization=None,
         device: torch.device = None,
         save_folder: str = None,
+        image_initializer=None,
     ):
 
         super().__init__(
@@ -42,6 +43,7 @@ class SupervisedSolver(LIONsolver):
         if verbose:
             print("Supervised solver training on device: ", device)
         self.op = make_operator(self.geometry)
+        self.image_initializer = image_initializer
 
     def mini_batch_step(self, sino, target):
         """
@@ -50,7 +52,11 @@ class SupervisedSolver(LIONsolver):
         """
         # Forward pass
         if self.model.get_input_type() == ModelInputType.IMAGE:
-            data = fdk(sino, self.op)
+            if self.image_initializer is not None:
+                data = self.image_initializer(sino, self.op)
+            else:
+                data = fdk(sino, self.op)
+            
             if self.do_normalise:
                 data = self.model.normalise.normalise(data)
                 target = self.model.normalise.normalise(target)


### PR DESCRIPTION
 This PR enhances SupervisedSolver by decoupling it from the hardcoded fdk initializer. The solver now optionally accepts an image_initializer argument, falling back to fdk only when this argument is not supplied. This resolves the feature request to allow for custom initializers or pre-trained networks when models expect an IMAGE input type.