### PR TITLE
Fix #166:  Fix loading error for models without geometry

### DIFF
--- a/LION/models/LIONmodel.py
+++ b/LION/models/LIONmodel.py
@@ -43,6 +43,7 @@ from abc import ABC, abstractmethod, ABCMeta
 # Some other imports
 import warnings
 from pathlib import Path
+import inspect
 
 
 class ModelInputType(int, Enum):
@@ -354,7 +355,8 @@ class LIONmodel(nn.Module, ABC):
         )
         # Some models need geometry, some others not.
         # This initializes the model itself (cls)
-        if hasattr(options, "geometry"):
+        sig = inspect.signature(cls.__init__)
+        if hasattr(options, "geometry") and "geometry" in sig.parameters:
             model = cls(
                 model_parameters=options.model_parameters,
                 geometry=options.geometry,
@@ -384,7 +386,8 @@ class LIONmodel(nn.Module, ABC):
         data = LIONmodel._load_data(fname, supress_warnings=True)
         # Some models need geometry, some others not.
         # This initializes the model itself (cls)
-        if hasattr(options, "geometry"):
+        sig = inspect.signature(cls.__init__)
+        if hasattr(options, "geometry") and "geometry" in sig.parameters:
             model = cls(
                 model_parameters=options.model_parameters,
                 geometry=options.geometry,


### PR DESCRIPTION
This PR addresses an issue where LIONmodel.load() blindly forwarded a geometry keyword argument to any initialized model when hasattr(options, 'geometry') evaluated to True. We now perform dynamic introspection of the specific model's __init__ signature using the inspect module, ensuring that the geometry parameter is only forwarded if the target model explicitly accepts it.