### PR TITLE
fix: remove unused enum value

### DIFF
--- a/LION/models/LIONmodel.py
+++ b/LION/models/LIONmodel.py
@@ -6,13 +6,13 @@
 # =============================================================================
 
 
-#%% This is a base class for LION models.
+# %% This is a base class for LION models.
 #
 # All classes must derive from this one.
 # It definest a bunch of auxiliary functions
 #
 
-#%% Imports
+# %% Imports
 
 # You will want to import LIONParameter, as all models must save and use Parameters.
 from enum import Enum
@@ -83,8 +83,10 @@ class LIONmodel(nn.Module, ABC):
                 f"Expected geometry to be of type Geometry or None, but got {type(geometry).__name__}. "
                 "If you passed positional arguments to the model, please verify their order matches the model's __init__ signature."
             )
-        
-        if model_parameters is not None and not isinstance(model_parameters, LIONModelParameter):
+
+        if model_parameters is not None and not isinstance(
+            model_parameters, LIONModelParameter
+        ):
             raise TypeError(
                 f"Expected model_parameters to be of type LIONModelParameter or None, but got {type(model_parameters).__name__}. "
                 "Ensure you are not accidentally passing a Geometry object as model_parameters."

--- a/LION/models/LIONmodel.py
+++ b/LION/models/LIONmodel.py
@@ -49,7 +49,7 @@ import inspect
 class ModelInputType(int, Enum):
     SINOGRAM = 0
     NOISY_RECON = 1
-    IMAGE = 1
+    IMAGE = 2
 
 
 # Class for Model parameters that should be true for all models


### PR DESCRIPTION
Previously, these two enums were both being represented by the same underlying integer, meaning they couldn't be differentiated from each other. This fix means they can now actually be separated!

Co-authored by Claude Code (Sonnet 5), reviewed by me