### PR TITLE
Fix three small bugs in core utils

### DIFF
--- a/LION/CTtools/ct_geometry.py
+++ b/LION/CTtools/ct_geometry.py
@@ -125,8 +125,7 @@ class Geometry(LIONParameter):
             angles=np.linspace(0, 2 * np.pi, 50, endpoint=False),
         )
 
-    staticmethod
-
+    @staticmethod
     def parallel_sparse_angle_parameters(image_shape=None):
         if image_shape is None:
             image_shape = [1, 512, 512]

--- a/LION/models/LIONmodel.py
+++ b/LION/models/LIONmodel.py
@@ -83,8 +83,10 @@ class LIONmodel(nn.Module, ABC):
                 f"Expected geometry to be of type Geometry or None, but got {type(geometry).__name__}. "
                 "If you passed positional arguments to the model, please verify their order matches the model's __init__ signature."
             )
-        
-        if model_parameters is not None and not isinstance(model_parameters, LIONModelParameter):
+
+        if model_parameters is not None and not isinstance(
+            model_parameters, LIONModelParameter
+        ):
             raise TypeError(
                 f"Expected model_parameters to be of type LIONModelParameter or None, but got {type(model_parameters).__name__}. "
                 "Ensure you are not accidentally passing a Geometry object as model_parameters."

--- a/LION/utils/normaliser.py
+++ b/LION/utils/normaliser.py
@@ -53,8 +53,8 @@ class Normalisation:
         # assume x is a torch tensor
         if self.type == "sample":
             # normalize each sample in batch separately
-            self.last_max = x.max(dim=(2, 3), keepdim=True)[0]
-            self.last_min = x.min(dim=(2, 3), keepdim=True)[0]
+            self.last_max = x.amax(dim=(2, 3), keepdim=True)
+            self.last_min = x.amin(dim=(2, 3), keepdim=True)
             return (x - self.last_min) / (self.last_max - self.last_min)
         if self.type == "dataset" or self.type == "custom":
             return (x - self.xmin) / (self.xmax - self.xmin)
@@ -69,7 +69,11 @@ class Normalisation:
                 return (x * (self.last_max - self.last_min)) + self.last_min
             else:
                 return (
-                    x * (target.max() - target.min(dim=(2, 3), keepdim=True)[0])
-                ) + target.min(dim=(2, 3), keepdim=True)[0]
+                    x
+                    * (
+                        target.amax(dim=(2, 3), keepdim=True)
+                        - target.amin(dim=(2, 3), keepdim=True)
+                    )
+                ) + target.amin(dim=(2, 3), keepdim=True)
         if self.type == "none":
             return x

--- a/LION/utils/parameter.py
+++ b/LION/utils/parameter.py
@@ -50,7 +50,7 @@ class LIONParameter:
         if isinstance(fname, str):
             fname = Path(fname)
         if fname.suffix != ".json":
-            fname.joinpath(".json")
+            fname = fname.with_suffix(".json")
         with open(fname, "w", encoding="utf-8") as f:
             json.dump(
                 self.serialize(), f, ensure_ascii=False, indent=4, cls=JSONParamEncoder

--- a/tests/classical_algorithms/test_sirt.py
+++ b/tests/classical_algorithms/test_sirt.py
@@ -19,6 +19,7 @@ sys.modules["ts_algorithms"] = MagicMock()
 
 class Geometry:
     """Minimal Geometry stub for isinstance checks."""
+
     pass
 
 
@@ -35,6 +36,7 @@ sys.modules["LION.operators.CTProjectionOp"] = MagicMock()
 
 class NoDataException(Exception):
     """Stub matching LION.exceptions.exceptions.NoDataException."""
+
     pass
 
 
@@ -62,6 +64,7 @@ import pytest
 
 class MockOp:
     """Minimal operator stub matching tomosipo's interface."""
+
     def __init__(self, domain_shape=(1, 16, 16), range_shape=(1, 20, 20)):
         self.domain_shape = domain_shape
         self.range_shape = range_shape
@@ -71,9 +74,7 @@ class MockOp:
 def mock_ts_sirt():
     """Replace the real ts_algorithms.sirt with a deterministic mock."""
     _sirt_mod.ts_sirt = MagicMock()
-    _sirt_mod.ts_sirt.side_effect = lambda op, y, *a, **kw: torch.zeros(
-        op.domain_shape
-    )
+    _sirt_mod.ts_sirt.side_effect = lambda op, y, *a, **kw: torch.zeros(op.domain_shape)
     yield
     _sirt_mod.ts_sirt = ts_sirt  # restore
 

--- a/tests/classical_algorithms/test_tv_min.py
+++ b/tests/classical_algorithms/test_tv_min.py
@@ -66,9 +66,7 @@ class MockOp:
 def mock_ts_tv_min():
     """Replace the real ts_algorithms.tv_min2d with a deterministic mock."""
     _tv_mod.ts_tv_min = MagicMock()
-    _tv_mod.ts_tv_min.side_effect = lambda op, y, *a, **kw: torch.zeros(
-        op.domain_shape
-    )
+    _tv_mod.ts_tv_min.side_effect = lambda op, y, *a, **kw: torch.zeros(op.domain_shape)
     yield
     _tv_mod.ts_tv_min = ts_tv_min
 


### PR DESCRIPTION
Three small fixes in core utils:

- `normaliser.py`: `Normalisation("sample")` crashed — torch `max/min` don't take a tuple dim; switched to `amax/amin` (and the target branch to per-batch).
- `ct_geometry.py`: a bare `staticmethod` (no `@`) left the method un-decorated, so instance calls raised `TypeError`; added the `@`.
- `parameter.py`: `save()` discarded the `joinpath('.json')` result, so suffix-less names saved without `.json`; now uses `with_suffix('.json')`.