### PR TITLE
Apply black formatting to three files

### DIFF
--- a/LION/models/LIONmodel.py
+++ b/LION/models/LIONmodel.py
@@ -83,8 +83,10 @@ class LIONmodel(nn.Module, ABC):
                 f"Expected geometry to be of type Geometry or None, but got {type(geometry).__name__}. "
                 "If you passed positional arguments to the model, please verify their order matches the model's __init__ signature."
             )
-        
-        if model_parameters is not None and not isinstance(model_parameters, LIONModelParameter):
+
+        if model_parameters is not None and not isinstance(
+            model_parameters, LIONModelParameter
+        ):
             raise TypeError(
                 f"Expected model_parameters to be of type LIONModelParameter or None, but got {type(model_parameters).__name__}. "
                 "Ensure you are not accidentally passing a Geometry object as model_parameters."

--- a/tests/classical_algorithms/test_sirt.py
+++ b/tests/classical_algorithms/test_sirt.py
@@ -19,6 +19,7 @@ sys.modules["ts_algorithms"] = MagicMock()
 
 class Geometry:
     """Minimal Geometry stub for isinstance checks."""
+
     pass
 
 
@@ -35,6 +36,7 @@ sys.modules["LION.operators.CTProjectionOp"] = MagicMock()
 
 class NoDataException(Exception):
     """Stub matching LION.exceptions.exceptions.NoDataException."""
+
     pass
 
 
@@ -62,6 +64,7 @@ import pytest
 
 class MockOp:
     """Minimal operator stub matching tomosipo's interface."""
+
     def __init__(self, domain_shape=(1, 16, 16), range_shape=(1, 20, 20)):
         self.domain_shape = domain_shape
         self.range_shape = range_shape
@@ -71,9 +74,7 @@ class MockOp:
 def mock_ts_sirt():
     """Replace the real ts_algorithms.sirt with a deterministic mock."""
     _sirt_mod.ts_sirt = MagicMock()
-    _sirt_mod.ts_sirt.side_effect = lambda op, y, *a, **kw: torch.zeros(
-        op.domain_shape
-    )
+    _sirt_mod.ts_sirt.side_effect = lambda op, y, *a, **kw: torch.zeros(op.domain_shape)
     yield
     _sirt_mod.ts_sirt = ts_sirt  # restore
 

--- a/tests/classical_algorithms/test_tv_min.py
+++ b/tests/classical_algorithms/test_tv_min.py
@@ -66,9 +66,7 @@ class MockOp:
 def mock_ts_tv_min():
     """Replace the real ts_algorithms.tv_min2d with a deterministic mock."""
     _tv_mod.ts_tv_min = MagicMock()
-    _tv_mod.ts_tv_min.side_effect = lambda op, y, *a, **kw: torch.zeros(
-        op.domain_shape
-    )
+    _tv_mod.ts_tv_min.side_effect = lambda op, y, *a, **kw: torch.zeros(op.domain_shape)
     yield
     _tv_mod.ts_tv_min = ts_tv_min
 


### PR DESCRIPTION
black --all-files in pre-commit flags LIONmodel.py and the two classical_algorithms tests (added in #194). Formatting only, no behavioural changes.