### PR TITLE
Fix loading errors in ACR, AR and cFBPConvNet

### DIFF
--- a/LION/models/learned_regularizer/ACR.py
+++ b/LION/models/learned_regularizer/ACR.py
@@ -9,7 +9,7 @@
 from typing import Optional
 import torch
 import torch.nn as nn
-from LION.models.LIONmodel import LIONmodel, ModelInputType, ModelParams
+from LION.models.LIONmodel import LIONmodel, ModelInputType, LIONModelParameter
 import LION.CTtools.ct_geometry as ct
 import torch.nn.utils.parametrize as P
 from LION.utils.math import power_method
@@ -77,7 +77,7 @@ class ACR(LIONmodel):
     def __init__(
         self,
         geometry_parameters: ct.Geometry,
-        model_parameters: Optional[ACRParams] = None,
+        model_parameters: Optional[LIONModelParameter] = None,
     ):
 
         super().__init__(model_parameters, geometry_parameters)
@@ -180,7 +180,7 @@ class ACR(LIONmodel):
         params.stride = 1
         params.relu_type = "LeakyReLU"
         params.layers = 5
-        params.input_type = ModelInputType.IMAGE
+        params.model_input_type = ModelInputType.IMAGE
         return params
 
     @staticmethod

--- a/LION/models/learned_regularizer/AR.py
+++ b/LION/models/learned_regularizer/AR.py
@@ -5,13 +5,13 @@
 # Modifications: Ander Biguri, Zakhar Shumaylov, Charlie Shoebridge
 # =============================================================================
 import torch.nn as nn
-from LION.models.LIONmodel import LIONmodel, ModelInputType, ModelParams
+from LION.models.LIONmodel import LIONmodel, ModelInputType, LIONModelParameter
 import LION.CTtools.ct_geometry as ct
 
 
 class AR(LIONmodel):
     def __init__(
-        self, model_parameters: LIONParameter, geometry_parametrs: ct.Geometry
+        self, model_parameters: LIONModelParameter, geometry_parametrs: ct.Geometry
     ):
         super().__init__(model_parameters, geometry_parametrs)
 

--- a/LION/models/post_processing/cFBPConvNet.py
+++ b/LION/models/post_processing/cFBPConvNet.py
@@ -206,7 +206,7 @@ class Up(nn.Module):
         return self.block(x)
 
 
-class cFBPConvNet(LIONmodel.LIONmodel):
+class cFBPConvNet(LIONmodel):
     def __init__(
         self,
         geometry_parameters: ct.Geometry,
@@ -442,7 +442,7 @@ class cFBPConvNet(LIONmodel.LIONmodel):
     @staticmethod
     def default_parameters():
         params = LIONModelParameter()
-        params = ModelInputType.IMAGE
+        params.model_input_type = ModelInputType.IMAGE
         params.down_1_channels = [64, 64, 64, 64]
         params.down_2_channels = [128, 128, 128]
         params.down_3_channels = [256, 256, 256]


### PR DESCRIPTION
Fix errors that prevented three models from loading or building their parameters.

- `ACR` and `AR` imported `ModelParams`, which doesn't exist in `LIONmodels` (the class is `LIONModelParameter`), so both raised `ImportError` on import. Also, `ACR.__init__` type-hinted `ACRParams` (undefined) and `AR.__init__` used `LIONParameter` without importing it; both now use `LIONModelParameter`, matching the base class.
- `cFBPConvNet` inherited from `LIONmodel.LIONmodel` (class used as a module) and raised `AttributeError` at class definition; now inherits from `LIONmodel`.
- `cFBPConvNet.default_parameters()` did `params = ModelInputType.IMAGE`, overwriting the parameter object with an int and raising `AttributeError` on the next assignment; it should be `params.model_input_type = ModelInputType.IMAGE`.
- `ACR.default_parameters()` set `params.input_type`, an attribute nothing reads, leaving `model_input_type` as `None`; now sets `params.model_input_type`.