### PR TITLE
Fix model construction errors

### DIFF
--- a/LION/models/CNNs/dncnn.py
+++ b/LION/models/CNNs/dncnn.py
@@ -17,6 +17,8 @@ class DnCNN(LIONmodel):
     def __init__(self, model_parameters: LIONParameter = None):
         super().__init__(model_parameters)
 
+        model_parameters = self.model_parameters
+
         if model_parameters.act.lower() in dict(
             getmembers(torch.nn.functional, isfunction)
         ):

--- a/LION/models/CNNs/drunet.py
+++ b/LION/models/CNNs/drunet.py
@@ -80,13 +80,16 @@ def upsample_convtranspose(
 class DRUNet(LIONmodel):
     def __init__(self, model_parameters: LIONParameter = None):
         super().__init__(model_parameters)
+
+        model_parameters = self.model_parameters
+
         if self.model_parameters.act.lower() in dict(
             getmembers(torch.nn.functional, isfunction)
         ):
             self._act = torch.nn.functional.__dict__[self.model_parameters.act]
         else:
             raise ValueError(
-                f"`torch.nn.functional` does not export a function '{model_parameters.act}'."
+                f"`torch.nn.functional` does not export a function '{self.model_parameters.act}'."
             )
         self.lift = torch.nn.Conv2d(
             (

--- a/LION/models/LIONmodel.py
+++ b/LION/models/LIONmodel.py
@@ -22,6 +22,7 @@ from LION.utils.parameter import LIONParameter
 # We will need utilities
 import LION.utils.utils as ai_utils
 from LION.utils.normaliser import Normalisation
+from LION.exceptions.exceptions import NoDataException
 
 # (optional) Given this is a tomography library, it is likely that you will want to load geometries of the tomogprahic problem you are solving, e.g. a ct_geometry
 import LION.CTtools.ct_geometry as ct

--- a/LION/models/PnP/gs_drunet.py
+++ b/LION/models/PnP/gs_drunet.py
@@ -5,7 +5,7 @@
 # Modifications: -
 # =============================================================================
 
-from .drunet import DRUNet
+from ..CNNs.drunet import DRUNet
 from LION.models.LIONmodel import LIONmodel, LIONModelParameter, ModelInputType
 from LION.utils.parameter import LIONParameter
 

--- a/LION/models/iterative_unrolled/ItNet.py
+++ b/LION/models/iterative_unrolled/ItNet.py
@@ -22,7 +22,7 @@ from LION.models.LIONmodel import LIONmodel, LIONModelParameter, ModelInputType
 from LION.models.CNNs.UNets.Unet import UNet
 
 
-class ItNet(LIONmodel.LIONmodel):
+class ItNet(LIONmodel):
     def __init__(self, geometry: ct.Geometry, model_parameters: LIONParameter = None):
         if geometry is None:
             raise ValueError("Geometry parameters required. ")

--- a/LION/models/iterative_unrolled/LG.py
+++ b/LION/models/iterative_unrolled/LG.py
@@ -45,7 +45,7 @@ class LGblock(nn.Module):
         return self.block(x)
 
 
-class LG(LIONmodel.LIONmodel):
+class LG(LIONmodel):
     def __init__(self, geometry: ct.Geometry, model_parameters: LIONParameter = None):
         super().__init__(model_parameters, geometry)
         self.geometry = geometry

--- a/LION/models/learned_regularizer/AR.py
+++ b/LION/models/learned_regularizer/AR.py
@@ -31,7 +31,7 @@ class AR(LIONmodel):
             self.leaky_relu,
         )
 
-        size = self.geo.image_shape[-1]
+        size = self.geometry.image_shape[-1]
         self.fc = nn.Sequential(
             nn.Linear(128 * (size // 2**4) ** 2, 256),
             self.leaky_relu,

--- a/LION/optimizers/GaussianDenoiserSolver.py
+++ b/LION/optimizers/GaussianDenoiserSolver.py
@@ -47,9 +47,9 @@ class GaussianDenoiserSolver(LIONsolver):
         self.patch = None
 
         # Make range of noise levels if noise_level is a single value
-        if noise_level.ndim == 1 and noise_level.size(0) == 1:
+        if noise_level.ndim == 1 and noise_level.shape[0] == 1:
             noise_level = np.array([noise_level[0], noise_level[0]])
-        elif noise_level.ndim != 1 or noise_level.size(0) != 2:
+        elif noise_level.ndim != 1 or noise_level.shape[0] != 2:
             raise LIONSolverException(
                 "noise_level must be a numpy array of length 2, or a single value."
             )


### PR DESCRIPTION
Fixes that let models be built from default parameters, without passing a parameter object:

- `dncnn.py`: model built with the local `model_parameters` argument (None by default) instead of the parsed ones; now rebinds to `self.model_parameters`.
- `drunet.py`: same rebind, plus a stale local reference inside an f-string; now uses `self.model_parameters`.
- `gs_drunet.py`: imported `DRUNet` from a relative path that does not exist; now from `CNNs`.
- `ItNet.py` / `LG.py`: inherited from nonexistent `LIONmodel.LIONmodel`; now from `LIONmodel`.
- `AR.py`: read the undefined `self.geo`; now `self.geometry`.
- `LIONmodel.py`: `NoDataException` was referenced but never imported in `set_normalisation`; now imported.
- `GaussianDenoiserSolver.py`: called the non-callable numpy `.size(0)`; now `.shape[0]`.