### PR TITLE
Fix validation and type-checking errors in optimizers

### DIFF
--- a/LION/optimizers/EquivariantSolver.py
+++ b/LION/optimizers/EquivariantSolver.py
@@ -46,7 +46,9 @@ class EquivariantSolver(LIONsolver):
         assert 360 % cardinality == 0
         angle_increment = 360 / cardinality
 
-        return [lambda x: TF.rotate(x, i * angle_increment) for i in range(cardinality)]
+        return [
+            lambda x, i=i: TF.rotate(x, i * angle_increment) for i in range(cardinality)
+        ]
 
     @staticmethod
     def default_parameters() -> LIONParameter:

--- a/LION/optimizers/GaussianDenoiserSolver.py
+++ b/LION/optimizers/GaussianDenoiserSolver.py
@@ -156,7 +156,7 @@ class GaussianDenoiserSolver(LIONsolver):
                     outputs = self.model(y)
                 validation_loss = np.append(
                     validation_loss,
-                    self.validation_fn(y.to(self.device), outputs.to(self.device))
+                    self.validation_fn(outputs.to(self.device), data.to(self.device))
                     .cpu()
                     .numpy(),
                 )

--- a/LION/optimizers/LIONsolver.py
+++ b/LION/optimizers/LIONsolver.py
@@ -491,7 +491,7 @@ class LIONsolver(ABC, metaclass=ABCMeta):
                     warnings.warn(f"Attribute {attr} is not callable")
                     return 2
         # just standrad type chekcking, error or warn, depends of settings
-        elif isinstance(getattr(self, attr), type):
+        elif not isinstance(getattr(self, attr), expected_type):
             if error:
                 raise ValueError(
                     f"Attribute {attr} is not of type {expected_type}, its {type(getattr(self, attr))}"
@@ -599,7 +599,8 @@ class LIONsolver(ABC, metaclass=ABCMeta):
                     data = fdk(data, self.op)
                 output = self.model(data.to(self.device))
                 test_loss = np.append(
-                    test_loss, self.testing_fn(output, target.to(self.device))
+                    test_loss,
+                    self.testing_fn(output, target.to(self.device)).cpu().numpy(),
                 )
 
         if self.verbose:


### PR DESCRIPTION
Four fixes in the optimizers:

- `EquivariantSolver` captured loop variables by reference, so all four transforms were the same `rotation_270`; added `i=i` so each transform stays distinct.
- `GaussianDenoiserSolver` passed `(y, outputs)` (noisy input vs. denoised output) to the validation function; now `(outputs, data)` so validation matches the training objective.
- `LIONsolver.check_training_ready` had `isinstance(x, type)` backwards, so wrong-typed attributes were never rejected; now `not isinstance(x, expected_type)`.
- `LIONsolver.test()` compared a GPU tensor with a numpy array; added `.cpu().numpy()` on the prediction.