### PR TITLE
Fix operator interface errors in CompositeOp and DebiasOp

### DIFF
--- a/LION/operators/CompositeOp.py
+++ b/LION/operators/CompositeOp.py
@@ -100,5 +100,4 @@ class CompositeOp(Operator):
     @property
     def range_shape(self) -> tuple[int, ...]:
         """Return the shape of the measurement range."""
-        # Opposite of domain_shape of wavelet since wavelet is Psi^{-1}
-        return self.wavelet.domain_shape
+        return self.phi.range_shape

--- a/LION/operators/DebiasOp.py
+++ b/LION/operators/DebiasOp.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from tabnanny import verbose
-
 import torch
 from tqdm import tqdm
 
@@ -113,6 +111,7 @@ def debias_ls(
     max_iter: int = 200,
     tol: float = 1e-5,
     progress_bar: bool = False,
+    verbose: bool = False,
 ) -> torch.Tensor:
     """Debiasing least squares on the support of w.
 


### PR DESCRIPTION
Two fixes in the operators:

- `CompositeOp.range_shape` returned `wavelet.domain_shape` (the wavelet input space), which is neither the coefficient space nor the measurement space; now returns `phi.range_shape`, matching the actual forward output shape.
- `DebiasOp` imported `verbose` from `tabnanny`, which shadowed the `verbose` parameter; removed the import and added `verbose: bool = False` to the signature.