### PR TITLE
Fix check_training_ready crashing on CPU-only machines

### DIFF
--- a/LION/optimizers/LIONsolver.py
+++ b/LION/optimizers/LIONsolver.py
@@ -236,7 +236,9 @@ class LIONsolver(ABC, metaclass=ABCMeta):
             error=False,
             autofill=autofill,
             verbose=verbose,
-            default=torch.device(torch.cuda.current_device()),
+            default=torch.device(
+                torch.cuda.current_device() if torch.cuda.is_available() else "cpu"
+            ),
         )
 
         # Test 2: is the model set? if not, raise error or warn


### PR DESCRIPTION
One fix in `LIONsolver.py`:

- `check_training_ready` passed `torch.device(torch.cuda.current_device())` as the default for the device attribute. Python evaluates keyword arguments at call time, so this unconditionally calls `torch.cuda.current_device()`, which raises on systems without CUDA even though `self.device` is already set in `__init__` and the default is never used. Now uses `torch.cuda.is_available()`, which is safe on CPU-only machines and preserves the GPU-default behavior.